### PR TITLE
Keep `id` args in res_cal

### DIFF
--- a/R/variance_function.R
+++ b/R/variance_function.R
@@ -110,7 +110,7 @@ res_cal <- function(y = NULL, x, w = NULL, by = NULL, precalc = NULL, id = NULL)
 
   }else list2env(precalc, envir = environment())
 
-  if(is.null(y)) return(list(x = x, w = w, inv = inv)) else {
+  if(is.null(y)) return(list(x = x, w = w, inv = inv,id = id)) else {
     is_sparse_y <- inherits(y, c("Matrix"))
     is_matrix_y <- !is_sparse_y && inherits(y, c("matrix"))
     dimnames_y <- dimnames(y)


### PR DESCRIPTION
Hello Martin,

Thanks a lot for your work proposed in `gustave`: this package allows us to make variance estimation in a clear and reproducible framework. 

I realized that the `id` argument of the `res_cal` function was not blocking (as it is the case for the `varDT` function for example). It is therefore possible to get results even if the rows order of precalculation object and the variable of interest are not the same. Nevertheless, this result does not seem correct.

Here is a small example:

``` r
library("gustave")

set.seed(02032023)


n <- 100L
p <- 10L

x <- matrix(rnorm(n*p), ncol = p)
y <- matrix(rexp(n), ncol = 1)
pik <- runif(n)

rownames(x) <- paste0("id_",1:n)
rownames(y) <- paste0("id_",1:n)

v_precalc <- varDT(x = x, pik = pik, id = rownames(x))

y_permute <- y[order(y),, drop = FALSE]



#Use of precomputed results : `var_DT`

## On permuted `y`
varDT(y = y_permute, precalc = v_precalc)
# Error in varDT(y = y_permute, precalc = v_precalc) : 
#   The names of the data matrix (y argument) do not match the reference id (id argument).


## On raw `y`
varDT(y = y, precalc = v_precalc)
#[1] 2528.84

# Here, we can see that one cannot run `var_DT` if rows from `y` and `x` are not in the same order.


#Use of precomputed results : On res_calc

#Here, we precomputed res_cal and then we decided to apply it on 
# - y : a vector with the same order as `x`
# - `y_permute` : a vector which is a permutation of `y` (hence, row names in `y_permute` are not in the same order as `x`)

res_cal_precalc <- res_cal(x = x, id = rownames(x))

res_cal_permute <- res_cal(y = y_permute, precalc = res_cal_precalc)

res_cal_raw <- res_cal(y = y, precalc = res_cal_precalc)

#There is no error message unless `varDT`.
#And results based on `y` and `y_permute` are different

res_cal_compare <- merge(res_cal_permute, res_cal_raw, by = 0,
                         suffixes = c("_permute","_raw"))

```

I don't know if this is done on purpose (sorry for this pull request if it is the case), but I have proposed a small modification to the `res_cal` function consisting of keeping the `id` argument when `res_cal` is used with `y = NULL` .
